### PR TITLE
fix: edge case when n_possible_pairs < max_pairs

### DIFF
--- a/docs/reference/lib/email.md
+++ b/docs/reference/lib/email.md
@@ -3,7 +3,7 @@
 This contains utilities, blockers, and comparers relevant to email addresses
 
 ::: mismo.lib.email.clean_email
-::: mismo.lib.email.split_email
+::: mismo.lib.email.ParsedEmail
 ::: mismo.lib.email.match_level
 ::: mismo.lib.email.EmailMatchLevel
 ::: mismo.lib.email.EmailsDimension

--- a/mismo/block/_util.py
+++ b/mismo/block/_util.py
@@ -68,7 +68,7 @@ def sample_all_pairs(
     """  # noqa: E501
     left = left.cache()
     right = right.cache()
-    n_possible_pairs = left.count().execute() * right.count().execute()
+    n_possible_pairs = int(left.count().execute() * right.count().execute())
     n_pairs = (
         n_possible_pairs if max_pairs is None else min(n_possible_pairs, max_pairs)
     )

--- a/mismo/block/tests/test_util.py
+++ b/mismo/block/tests/test_util.py
@@ -18,7 +18,7 @@ from mismo.block import sample_all_pairs
         (2, 3),
         (10, 99),
         # Edge case where n_possible_pairs < max_pairs
-        (3, 10_000_000)
+        (3, 10_000_000),
     ],
 )
 def test_sample_all_pairs(table_factory, n_records: int, max_pairs: int):
@@ -30,7 +30,7 @@ def test_sample_all_pairs(table_factory, n_records: int, max_pairs: int):
         }
     )
     df = sample_all_pairs(t, t, max_pairs=max_pairs).execute()
-    expected_pairs = min(n_records ** 2, max_pairs)
+    expected_pairs = min(n_records**2, max_pairs)
     assert df.columns.tolist() == ["record_id_l", "record_id_r", "value_l", "value_r"]
     assert len(df) == expected_pairs
     assert df.record_id_l.notnull().all()

--- a/mismo/cluster/test/test_connected_components.py
+++ b/mismo/cluster/test/test_connected_components.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
-
 import ibis
 from ibis.expr import types as ir
 import pandas as pd
 import pytest
 
 from mismo.cluster import connected_components
+from mismo.tests.util import get_clusters
 
 
 @pytest.fixture(params=["component", "cluster"])
@@ -145,14 +144,5 @@ def test_cc_max_iterations(table_factory):
 
 def _labels_to_clusters(
     labels: ir.Table, label_as: str = "component"
-) -> set[frozenset[Any]]:
-    labels = labels.rename(component=label_as)
-    assert labels.component.type() == ibis.dtype("int64")
-    df = labels.to_pandas()
-    cid_to_rid = {c: set() for c in set(df.component)}
-    for row in df.itertuples():
-        record_id = row.record_id
-        if isinstance(record_id, dict):
-            record_id = tuple(record_id.values())
-        cid_to_rid[row.component].add(record_id)
-    return {frozenset(records) for records in cid_to_rid.values()}
+) -> set[frozenset[int]]:
+    return get_clusters(labels[label_as], label=labels.record_id)

--- a/mismo/lib/email/__init__.py
+++ b/mismo/lib/email/__init__.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 from mismo.lib.email._core import EmailMatchLevel as EmailMatchLevel
 from mismo.lib.email._core import EmailsDimension as EmailsDimension
+from mismo.lib.email._core import ParsedEmail as ParsedEmail
 from mismo.lib.email._core import clean_email as clean_email
 from mismo.lib.email._core import match_level as match_level
-from mismo.lib.email._core import split_email as split_email

--- a/mismo/lib/email/_core.py
+++ b/mismo/lib/email/_core.py
@@ -33,9 +33,9 @@ class ParsedEmail:
     """A simple data class holding an email address that has been split into parts."""
 
     full: ir.StringValue
-    """The full email address, eg 'bob@gmail.com'."""
+    """The full email address, eg 'bob.smith@gmail.com'."""
     user: ir.StringValue
-    """The user part of the email address, eg 'bob'."""
+    """The user part of the email address, eg 'bob.smith' of 'bob.smith@gmail.com'"""
     domain: ir.StringValue
     """The domain part of the email address, eg 'gmail.com'."""
 

--- a/mismo/lib/email/_core.py
+++ b/mismo/lib/email/_core.py
@@ -29,22 +29,44 @@ def clean_email(email: ir.StringValue, *, normalize: bool = False) -> ir.StringV
     return email
 
 
-def split_email(email: ir.StringValue) -> ir.StructValue:
-    """Split an email address into <user>@<domain> parts
+class ParsedEmail:
+    """A simple data class holding an email address that has been split into parts."""
 
-    Parameters
-    ----------
-    email:
-        An email string, assumed to already be cleaned by ``clean_email``
+    full: ir.StringValue
+    """The full email address, eg 'bob@gmail.com'."""
+    user: ir.StringValue
+    """The user part of the email address, eg 'bob'."""
+    domain: ir.StringValue
+    """The domain part of the email address, eg 'gmail.com'."""
 
-    Returns
-    -------
-    parsed:
+    def __init__(self, full: ir.StringValue, /):
+        """Parse an email address from the full string.
+
+        Does no cleaning or normalization. If you want that, use `clean_email` first.
+
+        Parameters
+        ----------
+        full :
+            The full email address.
+        """
+        self.full = full
+        self.user = full.split("@")[0].nullif("")
+        self.domain = full.split("@")[1].nullif("")
+
+    def as_struct(self) -> ir.StructValue:
+        """Convert to an ibis struct.
+
+        Returns
+        -------
         An ibis struct<full:string, user:string, domain: domain>
-    """
-    parts = email.split("@")
-    user, domain = parts[0].nullif(""), parts[1].nullif("")
-    return ibis.struct({"full": email, "user": user, "domain": domain})
+        """
+        return ibis.struct(
+            {
+                "full": self.full,
+                "user": self.user,
+                "domain": self.domain,
+            }
+        )
 
 
 class EmailMatchLevel(MatchLevel):
@@ -87,7 +109,7 @@ def match_level(
     """
 
     def norm_and_parse(e):
-        return split_email(clean_email(e, normalize=True))
+        return ParsedEmail(clean_email(e, normalize=True))
 
     if isinstance(e1, ir.StringValue):
         e1 = norm_and_parse(e1)
@@ -145,7 +167,7 @@ class EmailsDimension:
         """Add a column with the parsed and normalized email addresses."""
         return t.mutate(
             get_column(t, self.column)
-            .map(lambda email: split_email(clean_email(email, normalize=True)))
+            .map(lambda email: ParsedEmail(clean_email(email, normalize=True)))
             .name(self.column_parsed)
         )
 

--- a/mismo/lib/email/tests/test_core.py
+++ b/mismo/lib/email/tests/test_core.py
@@ -43,11 +43,17 @@ def test_clean_email(input, exp):
         pytest.param(None, None, None, None, id="null"),
     ],
 )
-def test_split_email_address(input, expfull, expuser, expdomain):
-    result = email.split_email(ibis.literal(input, str)).execute()
-    assert result["full"] == expfull
-    assert result["user"] == expuser
-    assert result["domain"] == expdomain
+def test_ParsedEmail(input, expfull, expuser, expdomain):
+    parsed = email.ParsedEmail(ibis.literal(input, str))
+    assert parsed.full.execute() == expfull
+    assert parsed.user.execute() == expuser
+    assert parsed.domain.execute() == expdomain
+
+    assert parsed.as_struct().execute() == {
+        "full": expfull,
+        "user": expuser,
+        "domain": expdomain,
+    }
 
 
 @pytest.mark.parametrize(

--- a/mismo/lib/name/__init__.py
+++ b/mismo/lib/name/__init__.py
@@ -4,6 +4,7 @@ from ._blocker import NameBlocker as NameBlocker
 from ._clean import normalize_name as normalize_name
 from ._compare import NameComparer as NameComparer
 from ._compare import NameMatchLevel as NameMatchLevel
+from ._compare import equal_forgiving_typo as equal_forgiving_typo
 from ._dimension import NameDimension as NameDimension
 from ._nicknames import are_aliases as are_aliases
 from ._nicknames import is_nickname_for as is_nickname_for


### PR DESCRIPTION
This PR fixes an issue that was preventing `sample_all_pairs` from working when the total number of possible pairs is less than the defined maximum
